### PR TITLE
Fixed critical error

### DIFF
--- a/classes/ColdTrick/StaticPages/Notifications.php
+++ b/classes/ColdTrick/StaticPages/Notifications.php
@@ -18,7 +18,7 @@ class Notifications {
 	 */
 	public static function addLastEditorOnComment(\Elgg\Hook $hook) {
 		
-		$event = $hook->getParam();
+		$event = $hook->getParam('event');
 		if (!$event instanceof SubscriptionNotificationEvent) {
 			// only delayed notifications
 			return;


### PR DESCRIPTION
ELGG.CRITICAL: ArgumentCountError: Too few arguments to function
Elgg\HooksRegistrationService\Hook::getParam(), 0 passed in
\mod\static\classes\ColdTrick\StaticPages\Notifications.php on line 21
and at least 1 expected in
\vendor\elgg\elgg\engine\classes\Elgg\HooksRegistrationService\Hook.php:82